### PR TITLE
ostree-demo: automate customizations to kickstart

### DIFF
--- a/ostree-demo/README.md
+++ b/ostree-demo/README.md
@@ -22,6 +22,10 @@ Fork the demo's GitOps repo https://github.com/redhat-et/microshift-config into 
 
     GITOPS_REPO="https://github.com/MY_ORG/microshift-config"
 
+Set `UPGRADE_SERVER_IP` to the IP address of the current host:
+
+    export UPGRADE_SERVER_IP=192.168.122.67
+
 ### Building the ostrees and installer image
 Run the following to prepare for building the RHEL4Edge installer ISO containing the necessary MicroShift dependencies:
 
@@ -29,7 +33,7 @@ Run the following to prepare for building the RHEL4Edge installer ISO containing
 
 Update the kickstart file to point to your forked GitOps repo and build the ostree and installer images:
 
-    sed -i "s|https://github.com/redhat-et/microshift-config|${GITOPS_REPO}|" ./image-builder/kickstart.ks
+    ./image_builder/customize.sh
     sudo ./image-builder/build.sh
 
 If all goes well, you should find the following files in `./builds`

--- a/ostree-demo/image-builder/customize.sh
+++ b/ostree-demo/image-builder/customize.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [ -z "${GITOPS_REPO}" -o -z "${UPGRADE_SERVER_IP}" ]; then
+    echo "Please set GITOPS_REPO and UPGRADE_SERVER_IP" 1>&2
+    exit 1
+fi
+
+sed -i "s|https://github.com/redhat-et/microshift-config|${GITOPS_REPO}|" ./image-builder/kickstart.ks
+sed -i "s|http://192.168.178.105:8080/repo/|http://${UPGRADE_SERVER_IP}:8080/repo/|" ./image-builder/kickstart.ks


### PR DESCRIPTION
The kickstart file requires two customizations. Automate both of them
and update the documentation.