### PR TITLE
A few updates to the instructions to the hello-microshift demo

### DIFF
--- a/demos/hello-microshift-demo/README.md
+++ b/demos/hello-microshift-demo/README.md
@@ -52,11 +52,12 @@ Verify that the application is deployed and the route is accepted:
     NAME               HOST                     ADMITTED   SERVICE            TLS
     hello-microshift   hello-microshift.local   True       hello-microshift
 
-Add an entry to `/etc/hosts` to map the application's route (`hello-microshift.local`) to the machine's primary IP:
+Add an entry to `/etc/hosts` to map the application's route to the host's IP address. The route FQDN is in the `routes/hello-microsoft` route object in the `demo` namespace. It will be `hello-microshift.local` but we'll use an oc command to output the route into a BASH variable named `route`. We then associate the host's IP to the route FQDN to the /etc/hosts file.
 
     hostIP=$(ip route get 1.1.1.1 | grep -oP 'src \K\S+')
+    route=$(oc get routes/hello-microshift -n demo -o=jsonpath={.spec.host})
     sudo sed -i.bak '/hello-microshift.local/d' /etc/hosts
-    echo "${hostIP}  hello-microshift.local" | sudo tee -a /etc/hosts
+    echo "${hostIP}  ${route}" | sudo tee -a /etc/hosts
 
 Now, trying to `curl` the application's route should return the "Hello, MicroShift!" HTML page:
 

--- a/demos/hello-microshift-demo/README.md
+++ b/demos/hello-microshift-demo/README.md
@@ -55,7 +55,7 @@ Verify that the application is deployed and the route is accepted:
 Add an entry to `/etc/hosts` to map the application's route (`hello-microshift.local`) to the machine's primary IP:
 
     hostIP=$(ip route get 1.1.1.1 | grep -oP 'src \K\S+')
-    sudo sed -i .bak '/hello-microshift.local/d' /etc/hosts
+    sudo sed -i.bak '/hello-microshift.local/d' /etc/hosts
     echo "${hostIP}  hello-microshift.local" | sudo tee -a /etc/hosts
 
 Now, trying to `curl` the application's route should return the "Hello, MicroShift!" HTML page:
@@ -82,7 +82,7 @@ To remotely access the cluster using the `oc` client, copy the kubeconfig from t
 
     mkdir -p ~/.kube/config
     ssh -o "IdentitiesOnly=yes" -i ./builds/hello-microshift/demo/id_demo microshift@$MACHINE_IP "sudo cat /var/lib/microshift/resources/kubeadmin/kubeconfig" > ~/.kube/config
-    sed -i .bak 's|server: https://127.0.0.1:6443|server: https://hello-microshift.local:6443|' ~/.kube/config
+    sed -i.bak 's|server: https://127.0.0.1:6443|server: https://hello-microshift.local:6443|' ~/.kube/config
 
 Now you can access the cluster remotely:
 

--- a/demos/hello-microshift-demo/README.md
+++ b/demos/hello-microshift-demo/README.md
@@ -72,7 +72,7 @@ Next, let's access the cluster and application from outside the MicroShift machi
 
 If you're running the MicroShift on a VM _and_ your hypervisor connects instances via NAT, make sure to create port mappings from the hypervisor to guest ports 22 (ssh), 80 (http), and 6443 (K8s API).
 
-Oo the MicroShift VM, ensure proper `firewalld` services are open. Use the following command on the MicroShift machine to open the services in the running config of `firewalld`.
+On the MicroShift machine, ensure proper `firewalld` services are open. Use the following command on the MicroShift machine to open the services in the running config of `firewalld`.
 
     sudo firewall-cmd --add-service={ssh,http,kube-apiserver}
 

--- a/demos/hello-microshift-demo/README.md
+++ b/demos/hello-microshift-demo/README.md
@@ -52,7 +52,7 @@ Verify that the application is deployed and the route is accepted:
     NAME               HOST                     ADMITTED   SERVICE            TLS
     hello-microshift   hello-microshift.local   True       hello-microshift
 
-Add an entry to `/etc/hosts` to map the application's route to the host's IP address. The route FQDN is in the `routes/hello-microsoft` route object in the `demo` namespace. It will be `hello-microshift.local` but we'll use an oc command to output the route into a BASH variable named `route`. We then associate the host's IP to the route FQDN to the /etc/hosts file.
+Add an entry to `/etc/hosts` to map the application's route to the host's IP address. The route FQDN is in the `routes/hello-microshift` route object in the `demo` namespace. It will be `hello-microshift.local` but we'll use an oc command to output the route into a BASH variable named `route`. We then associate the host's IP to the route FQDN to the /etc/hosts file.
 
     hostIP=$(ip route get 1.1.1.1 | grep -oP 'src \K\S+')
     route=$(oc get routes/hello-microshift -n demo -o=jsonpath={.spec.host})

--- a/demos/hello-microshift-demo/README.md
+++ b/demos/hello-microshift-demo/README.md
@@ -76,7 +76,7 @@ Oo the MicroShift VM, ensure proper `firewalld` services are open. Use the follo
 
     sudo firewall-cmd --add-service={ssh,http,kube-apiserver}
 
-If you reboot the MicroShift machine, then these rules will be lost. To make the `firewalld` rules permanent, you may type on the MicroShift VM:
+If you reboot the MicroShift machine, then these rules will be lost. To make the `firewalld` rules permanent, you may type on the MicroShift machine:
 
     sudo firewall-cmd --runtime-to-permanent
 

--- a/demos/hello-microshift-demo/README.md
+++ b/demos/hello-microshift-demo/README.md
@@ -80,7 +80,7 @@ If you reboot the MicroShift machine, then these rules will be lost. To make the
 
     sudo firewall-cmd --runtime-to-permanent
 
-On your host that is attempting to access the MicroShift VM, you must to edit `/etc/hosts` to resolve `hello-microshift.local` to the MicroShift machine's IP, then you can `curl` the route and also access the page in your browser:
+On your host that is attempting to access the MicroShift machine, you must to edit `/etc/hosts` to resolve `hello-microshift.local` to the MicroShift machine's IP, then you can `curl` the route and also access the page in your browser:
 
     [user@core ~]$ curl http://hello-microshift.local
     <!DOCTYPE html>


### PR DESCRIPTION
I went through the `hello-microshift-demo` and discovered a few areas that could be enhanced. To begin with, the `sed` command should not include a space between `-i` and `.bak`. Additionally, I introduced an `oc` command, including the `jsonpath` parameter, to pull the route from `route/hello-microshift` into the BASH `route` variable instead of hardcoding 'hello-microshift.local' directly in the instructions.